### PR TITLE
Change route to go to login + signup cleanup

### DIFF
--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -19,7 +19,6 @@ export default function SignUp() {
 
   const handleSubmit = async (e: any) => {
     e.preventDefault(); // Prevent the default form submission behavior
-    console.log('rocks');
     await authService.signUpWithEmail(email, password, firstName, lastName, birthDate, sex, phone, insurance);
   };
 
@@ -33,7 +32,7 @@ export default function SignUp() {
         </svg>
 
         <h2 className="mt-4 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">
-            Signup Doctor Dashboard
+            Patient Signup
         </h2>
     </div>
 

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -21,7 +21,7 @@ export const IndexRoute = ({ children }: any) => {
     if (session) {
         return <Navigate to="/dashboard" />;
     } else {
-        return <Navigate to="/signup" />;
+        return <Navigate to="/login" />;
     }
 
 };
@@ -29,7 +29,7 @@ export const ProtectedRoute = ({ children }: any) => {
     const session = useAuth();
     if (!session) {
         // user is not authenticated
-        return <Navigate to="/signup" />;
+        return <Navigate to="/login" />;
     }
     return children;
 };


### PR DESCRIPTION
This changes the default landing page to take the user to the login page rather than the signup. I'm open for debate around what is best, but other sights I feel have preferred a sign-in page first.

Furthermore, this PR also changes the name from "Signup Doctor Dashboard" to "Patient Signup," with the implicit understanding that doctors will go through a separate route to create an account (e.g. via HR), which also partially contributes to the default route change.

Lastly, this removes a stray console.log statement that I left behind. Oops